### PR TITLE
Add analytics visualisations

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ The script will run multiple Monte Carlo simulations and generate several plots:
 3. **Circulating Supply Over Time** – tokens distributed to stakeholders.
 4. **Cumulative Verified Reports Over Time** – running total of verified reports.
 5. **Predicted Token Price Over Time** – simple price estimate based on emission pool utilization.
+6. **Δ Utility Demand vs Δ Supply** – scatter showing price changes against net demand shifts.
+7. **Price Sensitivity Analysis** – compare token price trajectories for multiple `PRICE_ALPHA` values.
+8. **Active Curator Count** – number of curators participating over time.
+9. **Stake Distribution** – box plot of curator stake each timestep.
+10. **Slashing and Reward Flows** – minted rewards versus slashed stake.
 
 ## Project Structure
 


### PR DESCRIPTION
## Summary
- extend token price update to use PRICE_ALPHA
- compute additional metrics in `run_simulation`
- add helper to sweep `PRICE_ALPHA` values
- implement multiple new plotting functions for advanced analytics
- expand README with descriptions of new charts

## Testing
- `python -m py_compile all_in_one.py`